### PR TITLE
api: add zooGetAcl

### DIFF
--- a/src/ZooKeeper/Internal/FFI.hsc
+++ b/src/ZooKeeper/Internal/FFI.hsc
@@ -65,6 +65,12 @@ foreign import ccall unsafe "hs_zk.h zoo_state"
 foreign import ccall unsafe "hs_zk.h zoo_recv_timeout"
   c_zoo_recv_timeout :: ZHandle -> IO CInt
 
+foreign import ccall unsafe "hs_zk.h hs_zoo_aget_acl"
+  c_hs_zoo_aget_acl
+    :: ZHandle -> BA## Word8
+    -> StablePtr PrimMVar -> Int -> Ptr AclCompletion
+    -> IO CInt
+
 foreign import ccall unsafe "hs_zk.h hs_zoo_acreate"
   c_hs_zoo_acreate
     :: ZHandle

--- a/src/ZooKeeper/Types.hs
+++ b/src/ZooKeeper/Types.hs
@@ -9,6 +9,7 @@ module ZooKeeper.Types
   , I.zooOpenAclUnsafe
   , I.zooReadAclUnsafe
   , I.zooCreatorAllAcl
+  , I.ZooAcl (..)
 
   , I.HsWatcherCtx (..)
 
@@ -18,6 +19,7 @@ module ZooKeeper.Types
   , I.StringCompletion (..)
   , I.StringsCompletion (..)
   , I.StringsStatCompletion (..)
+  , I.AclCompletion (..)
 
   , I.Stat (..)
 
@@ -46,6 +48,15 @@ module ZooKeeper.Types
   , pattern I.ZooLogWarn
   , pattern I.ZooLogInfo
   , pattern I.ZooLogDebug
+
+  , I.ZooPerm
+  , pattern I.ZooPermRead
+  , pattern I.ZooPermWrite
+  , pattern I.ZooPermCreate
+  , pattern I.ZooPermDelete
+  , pattern I.ZooPermAdmin
+  , pattern I.ZooPermAll
+  , I.compactZooPerms
 
   , I.StringVector (..)
   ) where


### PR DESCRIPTION
Since zookeeper has two main api for acl: `zoo_aget_acl`, `zoo_aset_acl`, this pull request only implement `zoo_aget_acl`  and left `zoo_aset_acl` undefined.